### PR TITLE
Add GetObject to query

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,64 @@
+# [Choice] Debian / Ubuntu version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+# See https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian
+ARG VARIANT=debian-10
+FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set env for tracking that we're running in a devcontainer
+ENV DEVCONTAINER=true
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+USER $USERNAME
+RUN mkdir -p ~/.local/bin
+ENV PATH /home/${USERNAME}/.local/bin:$PATH
+
+# Configure apt, install packages and general tools
+RUN sudo apt-get update \
+    && sudo apt-get -y install --no-install-recommends apt-utils dialog nano bash-completion sudo bsdmainutils \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && sudo apt-get -y install git iproute2 procps lsb-release figlet build-essential
+
+# Save command line history
+RUN echo "export HISTFILE=/home/$USERNAME/commandhistory/.bash_history" >> "/home/$USERNAME/.bashrc" \
+    && echo "export PROMPT_COMMAND='history -a'" >> "/home/$USERNAME/.bashrc" \
+    && mkdir -p /home/$USERNAME/commandhistory \
+    && touch /home/$USERNAME/commandhistory/.bash_history \
+    && chown -R $USERNAME /home/$USERNAME/commandhistory
+
+# Set env for tracking that we're running in a devcontainer
+ENV DEVCONTAINER=true
+
+# golang
+COPY scripts/golang.sh /tmp/
+RUN /tmp/golang.sh
+
+# Set up GOPATH
+ENV GOPATH /home/vscode/go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+#Set up go tools
+RUN \
+    # --> Delve for debugging
+    go get github.com/go-delve/delve/cmd/dlv@v1.6.0 \
+    # --> Go language server
+    && go get golang.org/x/tools/gopls@v0.6.6 \
+    # --> Go symbols and outline for go to symbol support and test support 
+    && go get github.com/acroca/go-symbols@v0.1.1 && go get github.com/ramya-rao-a/go-outline@7182a932836a71948db4a81991a494751eccfe77 \
+    # --> GolangCI-lint
+    && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sed 's/tar -/tar --no-same-owner -/g' | sh -s -- -b $(go env GOPATH)/bin
+
+# __DEVCONTAINER_SNIPPET_INSERT__ (control where snippets get inserted using the devcontainer CLI)
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.117.1/containers/go
+{
+	"name": "dora",
+	"dockerFile": "Dockerfile",
+
+	"mounts": [
+		// Keep command history 
+		"source=dora-bashhistory,target=/home/vscode/commandhistory",
+	],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"files.eol": "\n", 
+		"go.useLanguageServer": true,
+		"[go]": {
+			"editor.snippetSuggestions": "none",
+			"editor.formatOnSave": true,
+			"editor.codeActionsOnSave": {
+				"source.organizeImports": true
+			}
+		},
+		"gopls": {
+			"usePlaceholders": true, // add parameter placeholders when completing a function
+			// Experimental settings
+			"completeUnimported": true, // autocomplete unimported packages
+			"deepCompletion": true // enable deep completion
+		},
+		"go.delveConfig": {
+			"dlvLoadConfig": {
+				"followPointers": true,
+				"maxVariableRecurse": 1,
+				"maxStringLen": 1024,
+				"maxArrayValues": 64,
+				"maxStructFields": -1
+			},
+			"apiVersion": 2,
+			"showGlobalVariables": false,
+			"debugAdapter": "legacy"
+		}
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	// "extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "echo hello",
+
+	"remoteUser": "vscode",
+	
+	"extensions": [
+		"golang.go",
+		"stuartleeks.vscode-go-by-example",
+	]
+}

--- a/.devcontainer/scripts/golang.sh
+++ b/.devcontainer/scripts/golang.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+get_latest_release() {
+  curl --silent "https://go.dev/dl/" | grep -Po -m 1 '(\d+\.\d+\.\d+)\.linux-amd64' | sed 's/.linux-amd64//' | head -n 1
+}
+
+VERSION=${1:-"$(get_latest_release)"}
+INSTALL_DIR=${2:-"$HOME/.local/bin"}
+CMD=go
+NAME="Go Language"
+
+echo -e "\e[34m»»» 📦 \e[32mInstalling \e[33m$NAME \e[35mv$VERSION\e[0m ..."
+
+cd /tmp
+curl -fsSL https://go.dev/dl/go${VERSION}.linux-amd64.tar.gz -o golang.tar.gz
+
+sudo tar -xvf golang.tar.gz
+sudo rm -rf /usr/local/go
+rm -rf /tmp/golang.tar.gz
+sudo mv go /usr/local
+
+echo -e "\n\e[34m»»» 💾 \e[32mInstalled to: \e[33m$(which $CMD)"
+echo -e "\e[34m»»» 💡 \e[32mVersion details: \e[39m$($CMD version)"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # goreleaser folder
 dist/
+
+dora

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,9 @@ GOPATH:=$(shell go env GOPATH)
 
 .PHONY: test
 test:
+	go test ./... -v | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''
+
+
+.PHONY: test
+test-benchmark:
 	go test ./... -v -race -bench=. | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ fmt.Println(float)   // 3.14159
 
 3. Access arrays by index with bracket notation `[]`.
 
-4. **New**: Fetch by type to allow caller to ask for the proper Go type. For the time being, asking for objects or arrays in their entirety must be done through `GetString` which will return the chunk of JSON.
+4. **New**: Fetch by type to allow caller to ask for the proper Go type. `GetString` supports asking for objects or arrays in their entirety, and  will return the chunk of JSON. `GetObject` returns Go types. The return type for `GetObject` is `interface{}`. Simple values such as strings and booleans are returned as the corresponding Go type, Arrays are returned as `[]interface{}`, and objects are treated as `map[string]interface{}`.
     
     Current API:
     - `GetString`
     - `GetFloat64`
     - `GetBool`
+    - `GetObject`
 
 5. Next feature will be approaching this either with some sort of serialization option maybe similar to stdlib or a simpler one with no options that returns a map or something? Will think about that some.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/bradford-hamilton/dora
 
 go 1.14
+
+require github.com/stretchr/testify v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/golang.tar.gz
+++ b/golang.tar.gz
@@ -1,0 +1,2 @@
+<a href="https://dl.google.com/go/go1.17.8.linux-amd64.tar.gz">Found</a>.
+

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -38,8 +38,8 @@ type Type int
 // Value will eventually have some methods that all Values must implement. For now
 // it represents any JSON value (object | array | boolean | string | number | null)
 type Value interface {
-	// AsGoType() interface{}
 	String() string
+	GoType() interface{}
 }
 
 // Object represents a JSON object. It holds a slice of Property as its children,
@@ -62,6 +62,13 @@ func NewObject(sourceBuf *[]byte) Object {
 func (o Object) String() string {
 	return string((*o.sourceBuf)[o.Start:o.End])
 }
+func (o Object) GoType() interface{} {
+	result := map[string]interface{}{}
+	for _, property := range o.Children {
+		result[property.Key.String()] = property.Value.GoType()
+	}
+	return result
+}
 
 var _ Value = Object{}
 
@@ -83,6 +90,13 @@ func NewArray(sourceBuf *[]byte) Array {
 }
 func (a Array) String() string {
 	return string((*a.sourceBuf)[a.Start:a.End])
+}
+func (a Array) GoType() interface{} {
+	result := make([]interface{}, len(a.Children))
+	for i, child := range a.Children {
+		result[i] = child.GoType()
+	}
+	return result
 }
 
 var _ Value = Array{}
@@ -109,6 +123,9 @@ func (l Literal) String() string {
 		return fmt.Sprintf("%v", lit)
 	}
 }
+func (l Literal) GoType() interface{} {
+	return l.Value
+}
 
 var _ Value = Literal{}
 
@@ -123,6 +140,9 @@ type Property struct {
 func (p Property) String() string {
 	return fmt.Sprintf("%s=%s", p.Key.String(), p.Value.String())
 }
+func (p Property) GoType() interface{} {
+	return nil // TODO - revisit this
+}
 
 var _ Value = Property{}
 
@@ -134,6 +154,9 @@ type Identifier struct {
 
 func (i Identifier) String() string {
 	return i.Value
+}
+func (i Identifier) GoType() interface{} {
+	return nil // TODO - revisit this
 }
 
 var _ Value = Identifier{}

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1,6 +1,11 @@
 // Package ast TODO: package docs
 package ast
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // These are the available root node types. In JSON it will either be an
 // object or an array at the base.
 const (
@@ -30,29 +35,82 @@ const (
 // Type is a type alias for int. Represents a values type.
 type Type int
 
+// Value will eventually have some methods that all Values must implement. For now
+// it represents any JSON value (object | array | boolean | string | number | null)
+type Value interface {
+	// AsGoType() interface{}
+	String() string
+}
+
 // Object represents a JSON object. It holds a slice of Property as its children,
 // a Type ("Object"), and start & end code points for displaying.
 type Object struct {
-	Type     Type
-	Children []Property
-	Start    int
-	End      int
+	Type      Type
+	Children  []Property
+	Start     int
+	End       int
+	sourceBuf *[]byte
 }
+
+func NewObject(sourceBuf *[]byte) Object {
+	return Object{
+		Type:      ObjectType,
+		sourceBuf: sourceBuf,
+	}
+}
+
+func (o Object) String() string {
+	return string((*o.sourceBuf)[o.Start:o.End])
+}
+
+var _ Value = Object{}
 
 // Array represents a JSON array It holds a slice of Value as its children,
 // a Type ("Array"), and start & end code points for displaying.
 type Array struct {
-	Type     Type
-	Children []Value
-	Start    int
-	End      int
+	Type      Type
+	Children  []Value
+	Start     int
+	End       int
+	sourceBuf *[]byte
 }
+
+func NewArray(sourceBuf *[]byte) Array {
+	return Array{
+		Type:      ArrayType,
+		sourceBuf: sourceBuf,
+	}
+}
+func (a Array) String() string {
+	return string((*a.sourceBuf)[a.Start:a.End])
+}
+
+var _ Value = Array{}
 
 // Literal represents a JSON literal value. It holds a Type ("Literal") and the actual value.
 type Literal struct {
 	Type  Type
-	Value Value
+	Value interface{}
 }
+
+func (l Literal) String() string {
+	switch lit := l.Value.(type) {
+	case string:
+		return lit
+	case float64:
+		return fmt.Sprintf("%f", lit)
+	case int:
+		return strconv.Itoa(lit)
+	case bool:
+		return fmt.Sprintf("%v", lit)
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%v", lit)
+	}
+}
+
+var _ Value = Literal{}
 
 // Property holds a Type ("Property") as well as a `Key` and `Value`. The Key is an Identifier
 // and the value is any Value.
@@ -62,15 +120,23 @@ type Property struct {
 	Value Value
 }
 
+func (p Property) String() string {
+	return fmt.Sprintf("%s=%s", p.Key.String(), p.Value.String())
+}
+
+var _ Value = Property{}
+
 // Identifier represents a JSON object property key
 type Identifier struct {
 	Type  Type
 	Value string // "key1"
 }
 
-// Value will eventually have some methods that all Values must implement. For now
-// it represents any JSON value (object | array | boolean | string | number | null)
-type Value interface{}
+func (i Identifier) String() string {
+	return i.Value
+}
+
+var _ Value = Identifier{}
 
 // state is a type alias for int and used to create the available value states below
 type state int

--- a/pkg/danger/danger.go
+++ b/pkg/danger/danger.go
@@ -5,6 +5,21 @@ import (
 	"unsafe"
 )
 
+// // These method were implemented as a low-allocation, high-performance way to convert bytes<->string
+// // When running on go 1.178.8, the following error is reported
+// //      fatal error: checkptr: converted pointer straddles multiple allocations
+// // For now, falling back to the classic conversion approach, but would be good to revisit
+
+// func BytesToString(bytes []byte) (s string) {
+// 	return string(bytes)
+// }
+
+// func StringToBytes(s string) (b []byte) {
+// 	return []byte(s)
+// }
+
+// Original implemnentations below:
+
 // BytesToString turns a []byte into a string with 0 MemAllocs and 0 MemBytes.
 // This is an unsafe operation and may lead to problems if the bytes passed in
 // are changed while the string is used. No checking whether bytes are valid

--- a/pkg/dora/dora.go
+++ b/pkg/dora/dora.go
@@ -18,6 +18,7 @@ type Client struct {
 	query       []byte
 	parsedQuery []queryToken
 	result      string
+	resultValue ast.Value
 }
 
 // NewFromString takes a string, creates a lexer, creates a parser from the lexer,
@@ -72,3 +73,27 @@ func (c *Client) GetFloat64(query string) (float64, error) {
 	}
 	return f, nil
 }
+
+// // GetStringMap wraps a call to `get` and returns the result as a map[string]string
+// func (c *Client) GetStringMap(query string) (map[string]string, error) {
+// 	if err := c.prepAndExecQuery(query); err != nil {
+// 		return nil, err
+// 	}
+
+// 	resultRaw := c.resultValue
+
+// 	var resultObject ast.Object
+
+// 	switch t := resultRaw.(type) {
+// 	case ast.Object:
+// 		resultObject = t
+// 	default:
+// 		return nil, fmt.Errorf("The query specified (%q) must return an object for GetStringMap", query)
+// 	}
+
+// 	for	_, property := range resultObject.Children {
+// 		property.Value
+// 	}
+
+// 	return map[string]string{"todo": "hey"}, nil
+// }

--- a/pkg/dora/dora.go
+++ b/pkg/dora/dora.go
@@ -74,26 +74,10 @@ func (c *Client) GetFloat64(query string) (float64, error) {
 	return f, nil
 }
 
-// // GetStringMap wraps a call to `get` and returns the result as a map[string]string
-// func (c *Client) GetStringMap(query string) (map[string]string, error) {
-// 	if err := c.prepAndExecQuery(query); err != nil {
-// 		return nil, err
-// 	}
-
-// 	resultRaw := c.resultValue
-
-// 	var resultObject ast.Object
-
-// 	switch t := resultRaw.(type) {
-// 	case ast.Object:
-// 		resultObject = t
-// 	default:
-// 		return nil, fmt.Errorf("The query specified (%q) must return an object for GetStringMap", query)
-// 	}
-
-// 	for	_, property := range resultObject.Children {
-// 		property.Value
-// 	}
-
-// 	return map[string]string{"todo": "hey"}, nil
-// }
+// GetObject wraps a call to `get` and returns the result as an interface{}
+func (c *Client) GetObject(query string) (interface{}, error) {
+	if err := c.prepAndExecQuery(query); err != nil {
+		return nil, err
+	}
+	return c.resultValue.GoType(), nil
+}

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const TestJSON = `
@@ -173,6 +175,38 @@ func TestClient_GetString(t *testing.T) {
 		}
 	}
 }
+func TestClient_GetOObject_String(t *testing.T) {
+	tests := [...]struct {
+		query          string
+		expectedResult string
+	}{
+		{
+			query:          "$.data.users[0].first_name",
+			expectedResult: "bradford",
+		},
+		{
+			query:          "$.superNest.inner1.inner2.inner3.inner4[0].inner5.inner6",
+			expectedResult: "neato",
+		},
+	}
+
+	_ = tests
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		result, err := c.GetObject(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %s, got: %s", tt.expectedResult, result)
+		}
+	}
+}
 
 func TestClient_GetBool(t *testing.T) {
 	tests := [...]struct {
@@ -195,6 +229,36 @@ func TestClient_GetBool(t *testing.T) {
 		}
 
 		result, err := c.GetBool(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %T, got: %T", tt.expectedResult, result)
+		}
+	}
+}
+func TestClient_GetObject_Bool(t *testing.T) {
+	tests := [...]struct {
+		query          string
+		expectedResult bool
+	}{
+		{
+			query:          "$.enabled",
+			expectedResult: true,
+		},
+		{
+			query:          "$.disabled",
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		result, err := c.GetObject(tt.query)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -239,32 +303,74 @@ func TestClient_GetFloat64(t *testing.T) {
 		}
 	}
 }
+func TestClient_GetObject_Float64(t *testing.T) {
+	tests := [...]struct {
+		query          string
+		expectedResult float64
+	}{
+		{
+			query:          "$.PI",
+			expectedResult: 3.1415,
+		},
+		{
+			query:          "$.codes[1]",
+			expectedResult: 201.000000,
+		},
+		{
+			query:          "$.codes[4]",
+			expectedResult: 404.567,
+		},
+	}
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
 
-// func TestClient_GetStringMap(t *testing.T) {
-// 	tests := [...]struct {
-// 		query          string
-// 		expectedResult map[string]string
-// 	}{
-// 		{
-// 			query: "$.props",
-// 			expectedResult: map[string]string{
-// 				"name": "Alice",
-// 				"pet":  "dog",
-// 			},
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		c, err := NewFromString(TestJSON)
-// 		if err != nil {
-// 			t.Fatalf("\nError creating client: %v\n", err)
-// 		}
+		result, err := c.GetObject(tt.query)
+		if err != nil {
+			fmt.Println(err)
+		}
 
-// 		result, err := c.GetStringMap(tt.query)
-// 		if assert.Nil(t, err) {
-// 			assert.Equal(t, tt.expectedResult, result)
-// 		}
-// 	}
-// }
+		if result != tt.expectedResult {
+			t.Fatalf("Expected result type of %f, got: %f", tt.expectedResult, result)
+		}
+	}
+}
+
+func TestClient_GetObject(t *testing.T) {
+	tests := [...]struct {
+		query          string
+		expectedResult interface{}
+	}{
+		{
+			query: "$.props",
+			expectedResult: map[string]interface{}{
+				"name": "Alice",
+				"pet":  "dog",
+			},
+		},
+		{
+			query:          "$.codes",
+			expectedResult: []interface{}{200.0, 201.0, 400.0, 403.0, 404.567},
+		},
+		{
+			query:          "$.data.users[0].random_items",
+			expectedResult: []interface{}{true, map[string]interface{}{"dog_name": "ellie"}},
+		},
+	}
+	for _, tt := range tests {
+		c, err := NewFromString(TestJSON)
+		if err != nil {
+			t.Fatalf("\nError creating client: %v\n", err)
+		}
+
+		result, err := c.GetObject(tt.query)
+		if assert.Nil(t, err) {
+			assert.Equal(t, tt.expectedResult, result)
+		}
+	}
+}
 
 // Most recent bench: (faster than std lib!!!!!!!!!!!!!)
 // goos: darwin

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -372,6 +372,19 @@ func TestClient_GetObject(t *testing.T) {
 	}
 }
 
+func TestClient_GetObject_NonExistentKey(t *testing.T) {
+	c, err := NewFromString(TestJSON)
+	if err != nil {
+		t.Fatalf("\nError creating client: %v\n", err)
+	}
+
+	_, err = c.GetObject("$.non_existent_path")
+
+	if assert.Error(t, err) {
+		assert.Equal(t, &KeyNotFoundError{Key: "non_existent_path", Query: "$.non_existent_path"}, err)
+	}
+}
+
 // Most recent bench: (faster than std lib!!!!!!!!!!!!!)
 // goos: darwin
 // goarch: amd64

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -32,7 +32,11 @@ const TestJSON = `
     "date": "04/19/2020",
     "enabled": true,
 	"PI": 3.1415,
-	"disabled": false
+	"disabled": false,
+	"props": {
+		"name": "Alice",
+		"pet" : "dog"
+	}
 }`
 
 func TestScanQueryTokens(t *testing.T) {
@@ -152,6 +156,7 @@ func TestClient_GetString(t *testing.T) {
 		},
 	}
 
+	_ = tests
 	for _, tt := range tests {
 		c, err := NewFromString(TestJSON)
 		if err != nil {
@@ -234,6 +239,32 @@ func TestClient_GetFloat64(t *testing.T) {
 		}
 	}
 }
+
+// func TestClient_GetStringMap(t *testing.T) {
+// 	tests := [...]struct {
+// 		query          string
+// 		expectedResult map[string]string
+// 	}{
+// 		{
+// 			query: "$.props",
+// 			expectedResult: map[string]string{
+// 				"name": "Alice",
+// 				"pet":  "dog",
+// 			},
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		c, err := NewFromString(TestJSON)
+// 		if err != nil {
+// 			t.Fatalf("\nError creating client: %v\n", err)
+// 		}
+
+// 		result, err := c.GetStringMap(tt.query)
+// 		if assert.Nil(t, err) {
+// 			assert.Equal(t, tt.expectedResult, result)
+// 		}
+// 	}
+// }
 
 // Most recent bench: (faster than std lib!!!!!!!!!!!!!)
 // goos: darwin

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -3,7 +3,6 @@ package dora
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/bradford-hamilton/dora/pkg/ast"
 	"github.com/bradford-hamilton/dora/pkg/danger"
@@ -137,7 +136,7 @@ func (c *Client) executeQuery() error {
 			case ast.Literal:
 				// If we're on the final value, return it
 				if i == parsedQueryLen-1 {
-					c.setResultFromLiteral(v.Value)
+					c.setResultFromValue(v)
 				} else {
 					return errors.New("Sorry, it looks like your query isn't quite right")
 				}
@@ -167,30 +166,14 @@ func (c *Client) setFinalValue(currentType ast.Type, index int, obj ast.Object, 
 
 // setResultFromValue switches on an ast.Value type and assigns the appropriate result to the client
 func (c *Client) setResultFromValue(value ast.Value) {
+	c.resultValue = value
 	switch val := value.(type) {
 	case ast.Literal:
-		c.setResultFromLiteral(val.Value)
+		c.result = val.String()
 	case ast.Object:
 		c.result = string(c.input[val.Start:val.End])
 	case ast.Array:
-		c.result = string(c.input[val.Start:val.End])
-	}
-}
-
-// setResultFromLiteral is very similar to setResultFromValue, except it we know the value we're switching over
-// must be a Literal, meaning the assigned result will either be a string, number, boolean, or null
-func (c *Client) setResultFromLiteral(value ast.Value) {
-	switch lit := value.(type) {
-	case string:
-		c.result = lit
-	case float64:
-		c.result = fmt.Sprintf("%f", lit)
-	case int:
-		c.result = strconv.Itoa(lit)
-	case bool:
-		c.result = fmt.Sprintf("%v", lit)
-	case nil:
-		c.result = "null"
+		c.result = val.String()
 	}
 }
 

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -25,6 +25,18 @@ var (
 	)
 )
 
+var _ error = &KeyNotFoundError{}
+
+// StatusError is used to return informational errors
+type KeyNotFoundError struct {
+	Key   string
+	Query string
+}
+
+func (e *KeyNotFoundError) Error() string {
+	return fmt.Sprintf("Sorry, could not find a key with that value. Key: %q (Query: %q)", e.Key, e.Query)
+}
+
 // prepAndExecQuery prepares and executes a passed in query
 func (c *Client) prepAndExecQuery(query string) error {
 	if err := c.prepareQuery(query, c.tree.Type); err != nil {
@@ -115,7 +127,7 @@ func (c *Client) executeQuery() error {
 				}
 			}
 			if !found {
-				return fmt.Errorf("Sorry, could not find a key with that value. Key: %s", c.parsedQuery[i].key)
+				return &KeyNotFoundError{Key: c.parsedQuery[i].key, Query: string(c.query)}
 			}
 		} else { // If the query token we're on is asking for an array
 			if currentType != ast.ArrayType {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -80,7 +80,7 @@ func (p *Parser) parseValue() ast.Value {
 
 // parseJSONObject is called when an open left brace `{` token is found
 func (p *Parser) parseJSONObject() ast.Value {
-	obj := ast.Object{Type: ast.ObjectType}
+	obj := ast.NewObject(&p.lexer.Input)
 	objState := ast.ObjStart
 
 	for !p.currentTokenTypeIs(token.EOF) {
@@ -137,7 +137,7 @@ func (p *Parser) parseJSONObject() ast.Value {
 
 // parseJSONArray is called when an open left bracket `[` token is found
 func (p *Parser) parseJSONArray() ast.Value {
-	array := ast.Array{Type: ast.ArrayType}
+	array := ast.NewArray(&p.lexer.Input)
 	arrayState := ast.ArrayStart
 
 	for !p.currentTokenTypeIs(token.EOF) {


### PR DESCRIPTION
Add `GetObject` function for querying and returning a Go object (`interface{}`) 

- Add Value.String()
- Add GetObject method
- Add KeyNotFoundError
