### PR TITLE
Add GetObject to query

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ fmt.Println(float)   // 3.14159
 
 3. Access arrays by index with bracket notation `[]`.
 
-4. **New**: Fetch by type to allow caller to ask for the proper Go type. For the time being, asking for objects or arrays in their entirety must be done through `GetString` which will return the chunk of JSON.
-    
+4. **New**: Fetch by type to allow caller to ask for the proper Go type. `GetString` supports asking for objects or arrays in their entirety, and  will return the chunk of JSON. `GetObject` returns Go types. The return type for `GetObject` is `interface{}`. Simple values such as strings and booleans are returned as the corresponding Go type, Arrays are returned as `[]interface{}`, and objects are treated as `map[string]interface{}`.
+
     Current API:
     - `GetString`
     - `GetFloat64`
     - `GetBool`
+    - `GetObject`
 
 5. Next feature will be approaching this either with some sort of serialization option maybe similar to stdlib or a simpler one with no options that returns a map or something? Will think about that some.
 

--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -1,6 +1,11 @@
 // Package ast TODO: package docs
 package ast
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // These are the available root node types. In JSON it will either be an
 // object or an array at the base.
 const (
@@ -63,6 +68,20 @@ type Object struct {
 	Start           int
 	End             int
 	SuffixStructure []StructuralItem
+	sourceBuf       *[]byte
+}
+
+var _ ValueContent = Object{}
+
+func NewObject(sourceBuf *[]byte) Object {
+	return Object{
+		Type:      ObjectType,
+		sourceBuf: sourceBuf,
+	}
+}
+
+func (o Object) String() string {
+	return string((*o.sourceBuf)[o.Start:o.End])
 }
 
 // Array represents a JSON array It holds a slice of Value as its children,
@@ -74,6 +93,20 @@ type Array struct {
 	SuffixStructure []StructuralItem
 	Start           int
 	End             int
+	sourceBuf       *[]byte
+}
+
+var _ ValueContent = Array{}
+
+func NewArray(sourceBuf *[]byte) Array {
+	return Array{
+		Type:      ArrayType,
+		sourceBuf: sourceBuf,
+	}
+}
+
+func (a Array) String() string {
+	return string((*a.sourceBuf)[a.Start:a.End])
 }
 
 // Array holds a Type ("ArrayItem") as well as a `Value` and whether there is a comma after the item
@@ -85,13 +118,38 @@ type ArrayItem struct {
 	HasCommaSeparator  bool
 }
 
+var _ ValueContent = ArrayItem{}
+
+func (ai ArrayItem) String() string {
+	return ai.Value.String()
+}
+
 // Literal represents a JSON literal value. It holds a Type ("Literal") and the actual value.
 type Literal struct {
 	Type              Type
 	ValueType         LiteralValueType
-	Value             ValueContent
+	Value             interface{}
 	Delimiter         string // Delimiter is set for string values
 	OriginalRendering string // Allows preservig numeric formatting from source documents
+}
+
+var _ ValueContent = Literal{}
+
+func (l Literal) String() string {
+	switch lit := l.Value.(type) {
+	case string:
+		return lit
+	case float64:
+		return fmt.Sprintf("%f", lit)
+	case int:
+		return strconv.Itoa(lit)
+	case bool:
+		return fmt.Sprintf("%v", lit)
+	case nil:
+		return "null"
+	default:
+		return fmt.Sprintf("%v", lit)
+	}
 }
 
 // Property holds a Type ("Property") as well as a `Key` and `Value`. The Key is an Identifier
@@ -118,9 +176,17 @@ type Value struct {
 	SuffixStructure []StructuralItem
 }
 
+var _ ValueContent = Value{}
+
+func (v Value) String() string {
+	return v.Content.String()
+}
+
 // ValueContent will eventually have some methods that all Values must implement. For now
 // it represents any JSON value (object | array | boolean | string | number | null)
-type ValueContent interface{}
+type ValueContent interface {
+	String() string
+}
 
 // state is a type alias for int and used to create the available value states below
 type state int

--- a/pkg/dora/dora.go
+++ b/pkg/dora/dora.go
@@ -18,6 +18,7 @@ type Client struct {
 	query       []byte
 	parsedQuery []queryToken
 	result      string
+	resultValue ast.ValueContent
 }
 
 // NewFromString takes a string, creates a lexer, creates a parser from the lexer,
@@ -71,4 +72,12 @@ func (c *Client) GetFloat64(query string) (float64, error) {
 		return 0.0, err
 	}
 	return f, nil
+}
+
+// GetObject wraps a call to `get` and returns the result as an interface{}
+func (c *Client) GetObject(query string) (interface{}, error) {
+	if err := c.prepAndExecQuery(query); err != nil {
+		return nil, err
+	}
+	return c.resultValue.GoType(), nil
 }

--- a/pkg/dora/dora_test.go
+++ b/pkg/dora/dora_test.go
@@ -385,6 +385,19 @@ func TestClient_GetObject(t *testing.T) {
 	}
 }
 
+func TestClient_GetObject_NonExistentKey(t *testing.T) {
+	c, err := NewFromString(TestJSON)
+	if err != nil {
+		t.Fatalf("\nError creating client: %v\n", err)
+	}
+
+	_, err = c.GetObject("$.non_existent_path")
+
+	if assert.Error(t, err) {
+		assert.Equal(t, &KeyNotFoundError{Key: "non_existent_path", Query: "$.non_existent_path"}, err)
+	}
+}
+
 // Most recent bench: (faster than std lib!!!!!!!!!!!!!)
 // goos: darwin
 // goarch: amd64

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -25,6 +25,18 @@ var (
 	)
 )
 
+var _ error = &KeyNotFoundError{}
+
+// StatusError is used to return informational errors
+type KeyNotFoundError struct {
+	Key   string
+	Query string
+}
+
+func (e *KeyNotFoundError) Error() string {
+	return fmt.Sprintf("Sorry, could not find a key with that value. Key: %q (Query: %q)", e.Key, e.Query)
+}
+
 // prepAndExecQuery prepares and executes a passed in query
 func (c *Client) prepAndExecQuery(query string) error {
 	if err := c.prepareQuery(query, c.tree.Type); err != nil {
@@ -118,7 +130,7 @@ func (c *Client) executeQuery() error {
 				}
 			}
 			if !found {
-				return fmt.Errorf("sorry, could not find a key with that value. Key: %s", c.parsedQuery[i].key)
+				return &KeyNotFoundError{Key: c.parsedQuery[i].key, Query: string(c.query)}
 			}
 		} else { // If the query token we're on is asking for an array
 			if currentType != ast.ArrayType {

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -164,6 +164,7 @@ func (c *Client) setResultFromValue(value ast.ValueContent) {
 		// unwrap the Value
 		value = v2.Content
 	}
+	c.resultValue = value
 	c.result = value.String()
 }
 

--- a/pkg/dora/query.go
+++ b/pkg/dora/query.go
@@ -99,7 +99,7 @@ func (c *Client) executeQuery() error {
 
 					// If i == parsedQueryLen-1, we are on the final iteration
 					if i == parsedQueryLen-1 {
-						c.setResultFromValue(val)
+						c.setResultFromValue(val.Content)
 						return nil
 					}
 
@@ -143,7 +143,7 @@ func (c *Client) executeQuery() error {
 			case ast.Literal:
 				// If we're on the final value, return it
 				if i == parsedQueryLen-1 {
-					c.setResultFromLiteral(v.Value)
+					c.setResultFromValue(v)
 				} else {
 					return errors.New("sorry, it looks like your query isn't quite right")
 				}
@@ -164,31 +164,7 @@ func (c *Client) setResultFromValue(value ast.ValueContent) {
 		// unwrap the Value
 		value = v2.Content
 	}
-	switch val := value.(type) {
-	case ast.Literal:
-		c.setResultFromLiteral(val.Value)
-	case ast.Object:
-		c.result = string(c.input[val.Start:val.End])
-	case ast.Array:
-		c.result = string(c.input[val.Start:val.End])
-	}
-}
-
-// setResultFromLiteral is very similar to setResultFromValue, except it we know the value we're switching over
-// must be a Literal, meaning the assigned result will either be a string, number, boolean, or null
-func (c *Client) setResultFromLiteral(value ast.ValueContent) {
-	switch lit := value.(type) {
-	case string:
-		c.result = lit
-	case float64:
-		c.result = fmt.Sprintf("%f", lit)
-	case int, int64:
-		c.result = fmt.Sprintf("%d", lit)
-	case bool:
-		c.result = fmt.Sprintf("%v", lit)
-	case nil:
-		c.result = "null"
-	}
+	c.result = value.String()
 }
 
 // validateQueryRoot handles some very simple validation around the root of the query

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -109,7 +109,7 @@ func (p *Parser) parseArrayItem() ast.ArrayItem {
 
 // parseJSONObject is called when an open left brace `{` token is found
 func (p *Parser) parseJSONObject() ast.ValueContent {
-	obj := ast.Object{Type: ast.ObjectType}
+	obj := ast.NewObject(&p.lexer.Input)
 	objState := ast.ObjStart
 
 	for !p.currentTokenTypeIs(token.EOF) {
@@ -181,7 +181,7 @@ func (p *Parser) parseJSONObject() ast.ValueContent {
 
 // parseJSONArray is called when an open left bracket `[` token is found
 func (p *Parser) parseJSONArray() ast.ValueContent {
-	array := ast.Array{Type: ast.ArrayType}
+	array := ast.NewArray(&p.lexer.Input)
 	arrayState := ast.ArrayStart
 
 	array.PrefixStructure = p.parseStructure()


### PR DESCRIPTION
Add `GetObject` function for querying and returning a Go object (`interface{}`) 

- Add Value.String()
- Add GetObject method
- Add KeyNotFoundError

Reworked #1 against the correct target branch!